### PR TITLE
Add a requirements.txt file to track dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django==1.6.1
+mock==1.0.1
+requests==2.2.1


### PR DESCRIPTION
I had to work my way installing the packages required to run the application and its test, so I thought this could be made easier by adding a requirements.txt listing the dependencies (generated with pip freeze).

I'm not sure whether this is the best way to manage dependencies with Python, but it seemed to be simplest.
