### PR TITLE
Add a new application that handles pull requests and updates Jira based on the comments.

### DIFF
--- a/github_webhooks/internal_settings.py.sample
+++ b/github_webhooks/internal_settings.py.sample
@@ -26,3 +26,27 @@ TRYBOT_BASE_URL = ''
 # Buildbot URL to which we are going to send a new patch.
 # It should be something like http://example.com/send_try_patch
 TRYBOT_SEND_PATCH_URL = ''
+
+### JIRA parameters ###
+
+# URL of the Jira server to update
+JIRA_SERVER = ''
+
+# Username of the Jira user that will comment on issues
+JIRA_USER = ''
+
+# The password of the Jira user
+JIRA_PASSWORD = ''
+
+# Enable or disable the client-side SSL certificate validation. Preferrably
+# this would be True, but in some setups it may need to be False
+JIRA_VERIFY_SSL = True
+
+# The Jira project string used as a prefix for issues IDs
+JIRA_PROJECT = ''
+
+# The ID of the "Resolve" transition
+JIRA_TRANSITION_RESOLVE_ID = ''
+
+# The ID of the "Fixed" resolution
+JIRA_RESOLUTION_FIXED_ID = ''

--- a/github_webhooks/settings.py
+++ b/github_webhooks/settings.py
@@ -16,6 +16,7 @@ DATABASES = {
 INSTALLED_APPS = (
     'github_webhooks',
     'trybot_control',
+    'jira_updater'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/github_webhooks/test/utils.py
+++ b/github_webhooks/test/utils.py
@@ -47,14 +47,17 @@ def mock_pull_request_payload():
             'patch_url': 'https://path/to/42.patch',
             'title': 'Hello world',
             'body': 'some description',
+            'html_url': 'http://pr.com',
             'user': {
                 'login': 'rakuco',
+                'html_url': 'http://rakuco.com',
             },
             'head': {
                 'sha': 'deadbeef',
                 'repo': {
                     'name': 'crosswalk-fork',
                     'full_name': 'rakuco/crosswalk-fork',
+                    'html_url': 'http://fork.com',
                 },
             },
             'base': {

--- a/jira_updater/__init__.py
+++ b/jira_updater/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Import handlers.py so that the signal handlers are properly registered.
+import jira_updater.handlers

--- a/jira_updater/handlers.py
+++ b/jira_updater/handlers.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Responds to the "pull_request_changed" event signal and updates JIRA
+based on the PR description.
+
+If the PR was opened, its body is scanned for references to JIRA issue
+ids or URLs. For each one that is mentioned, a comment is added to the issue
+in JIRA referencing the PR in Github.
+
+If the PR was closed, each issue mentioned in the following form will be
+resolved:
+
+BUG=<any text>ISSUE-1
+
+with typical examples being:
+
+BUG=ISSUE-1
+BUG=http://jira.server/browse/ISSUE-1
+"""
+
+import logging
+import re
+
+from django.conf import settings
+from django.dispatch import receiver
+from jirahelper import JiraHelper
+
+from github_webhooks.signals import pull_request_changed
+
+
+def search_issues(pr_body):
+    """
+    Parse the PR body searching for issue IDs and return a list
+    of issues in the form:
+    {
+        'id': <issue id>,
+        'resolve': <True if the comment indicates that
+           the issue is fixed by this PR>
+    }
+    """
+    issues = []
+    processed_issues = set()
+    regexp = re.compile(r'(%s-\d+)' % settings.JIRA_PROJECT)
+    for line in pr_body.splitlines():
+        match = regexp.search(line)
+        if not match:
+            continue
+        issue_id = match.group(1)
+        should_resolve = line.startswith('BUG=')
+        if issue_id not in processed_issues:
+            processed_issues.add(issue_id)
+            issues.append({'id': issue_id, 'resolve': should_resolve})
+    return issues
+
+
+@receiver(pull_request_changed)
+def handle_pull_request(sender, **kwargs):
+    payload = kwargs['payload']
+    pr_body = payload['pull_request']['body']
+    pr_action = payload['action']
+
+    jira = JiraHelper()
+    for issue in search_issues(pr_body):
+        if pr_action == 'opened':
+            jira.comment_issue(issue['id'], payload)
+            logging.debug('Commented on issue %s' % issue['id'])
+        elif pr_action == 'closed' and\
+                payload['pull_request']['merged'] and\
+                issue['resolve']:
+            jira.resolve_issue(issue['id'], payload)
+            logging.debug('Resolved issue %s' % issue['id'])
+        else:
+            logging.debug('Nothing to do with issue %s' %
+                          issue['id'])

--- a/jira_updater/jirahelper.py
+++ b/jira_updater/jirahelper.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from jira.client import JIRA
+from jira.exceptions import JIRAError
+from django.conf import settings
+import logging
+
+open_comment_template = (
+    '(i) [{user_id}|{user_url}] referenced this issue in project'
+    ' [{repo_name}|{repo_url}]:\n\n*[Pull Request '
+    '{pr_number}|{pr_url}]* _"{pr_title}"_')
+
+close_comment_template = (
+    '(/) [{user_id}|{user_url}] resolved this issue with '
+    '*[Pull Request {pr_number}|{pr_url}]*')
+
+
+class JiraHelper:
+    """
+    Connects to Jira server and provides high-level methods
+    to comment and resolve issues based on data from a PR
+    """
+    def __init__(self):
+        self.jira = None
+
+    def _jira(self):
+        """
+        Initialize the connection to the JIRA server
+        """
+        if self.jira is None:
+            options = {
+                'server': settings.JIRA_SERVER,
+                'verify': settings.JIRA_VERIFY_SSL
+            }
+            self.jira = JIRA(options, basic_auth=(settings.JIRA_USER,
+                                                  settings.JIRA_PASSWORD))
+        return self.jira
+
+    def comment_issue(self, issue_id, payload):
+        comment = open_comment_template.format(
+            user_id=payload['pull_request']['user']['login'],
+            user_url=payload['pull_request']['user']['html_url'],
+            repo_name=payload['pull_request']['head']['repo']['name'],
+            repo_url=payload['pull_request']['head']['repo']['html_url'],
+            pr_number=payload['pull_request']['number'],
+            pr_url=payload['pull_request']['html_url'],
+            pr_title=payload['pull_request']['title'])
+
+        try:
+            self._jira().add_comment(issue_id, comment)
+        except JIRAError as e:
+            logging.info('Could not comment issue %s: %s' %
+                        (issue_id, e.text))
+
+    def resolve_issue(self, issue_id, payload):
+        comment = close_comment_template.format(
+            user_id=payload['pull_request']['user']['login'],
+            user_url=payload['pull_request']['user']['html_url'],
+            pr_number=payload['pull_request']['number'],
+            pr_url=payload['pull_request']['html_url'])
+
+        try:
+            self._jira().add_comment(issue_id, comment)
+            issue = self._jira().issue(issue_id)
+            self._jira().transition_issue(
+                issue,
+                settings.JIRA_TRANSITION_RESOLVE_ID,
+                resolution={'id': settings.JIRA_RESOLUTION_FIXED_ID})
+        except JIRAError as e:
+            logging.info('Could not resolve issue %s: %s' %
+                        (issue_id, e.text))

--- a/jira_updater/test_handlers.py
+++ b/jira_updater/test_handlers.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from mock import patch, ANY, Mock
+
+from django.test import TestCase
+from django.test.client import Client
+from django.core.urlresolvers import reverse
+from django.conf import settings
+
+from github_webhooks.test.utils import GitHubEventClient
+from github_webhooks.test.utils import mock_pull_request_payload
+from jira_updater.handlers import handle_pull_request
+from jira_updater.handlers import search_issues
+
+
+class JiraUpdaterTestCase(TestCase):
+    def setUp(self):
+        settings.JIRA_PROJECT = 'PROJ'
+
+    def test_regexp_no_issue(self):
+        text = 'Text with no issue'
+        issues = search_issues(text)
+        self.assertEqual(issues, [])
+
+    def test_regexp_mention_issue(self):
+        text = 'Text mentioning issue PROJ-1'
+        issues = search_issues(text)
+        self.assertEqual(len(issues), 1)
+
+    @patch('jira_updater.jirahelper.JIRA')
+    def test_no_issue(self, jira_mock):
+        payload = mock_pull_request_payload()
+        payload['pull_request']['body'] = 'This PR does not fix any issue'
+        handle_pull_request(None, payload=payload)
+        self.assertEqual(jira_mock.called, False)
+
+    @patch('jira_updater.jirahelper.JIRA')
+    def test_comment_issue(self, jira_mock):
+        payload = mock_pull_request_payload()
+        payload['pull_request']['body'] = \
+            'This PR will resolve the issue'\
+            'mentioned below:'\
+            '\n'\
+            'BUG=https://crosswalk-project.org/jira/bug=PROJ-2'
+        handle_pull_request(None, payload=payload)
+        jira_mock.return_value.add_comment.assert_called_with('PROJ-2', ANY)
+
+    @patch('jira_updater.jirahelper.JIRA')
+    def test_resolve_issue(self, jira_mock):
+        payload = mock_pull_request_payload()
+        payload['action'] = 'closed'
+        payload['pull_request']['body'] = \
+            'This PR will close the issue'\
+            'mentioned below:'\
+            '\n'\
+            'BUG=https://crosswalk-project.org/jira/bug=PROJ-2'
+        payload['pull_request']['merged'] = True
+        issue_mock = Mock()
+        jira_mock.return_value.issue.return_value = issue_mock
+        handle_pull_request(None, payload=payload)
+        jira_mock.return_value.issue.assert_called_with('PROJ-2')
+        jira_mock.return_value.add_comment.assert_called_with('PROJ-2', ANY)
+        jira_mock.return_value.transition_issue.assert_called_with(
+            issue_mock,
+            settings.JIRA_TRANSITION_RESOLVE_ID,
+            resolution={'id': settings.JIRA_RESOLUTION_FIXED_ID}
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.6.1
+jira-python==0.16
 mock==1.0.1
 requests==2.2.1


### PR DESCRIPTION
This PR introduces a new application named "jira_updater" that registers itself as a handler for "pull_request_changed". When a PR "opened" or "closed" event is received, the body of the PR is scanned looking for issue IDs, and for each of them a comment is added to Jira mentioning the author, commit, pr number and other information (the format imitates the one used by github when commits reference Github issues). Additionally, if the PR comments says that the issue is resolved, the issue is marked as "resolved/fixed".

Below is a summary of the changes:
- add JIRA connection parameters to internal.settings.py.sample
- register the jira_updater application in settings.py
- add a few URL parameters required by the app to the mock_pull_request_payload
- add a new module jira_updater.py, containing the handler (handlers.py) and jira utility functions (jirahelper.py)
- add a few tests for the main use cases (there is room for more)

Random notes:
- When testing the handler I'm directly injecting the PR payload in handle_pull_request rather than using the HTTP test client. This is because using the test client means that I also need to provide stubs for github to make the tryboy_control tests pass, which didn't seem like a self-contained way to define tests (plus this was easier :P)
- in addition to the unit tests, I did a few manual tests against crosswalk-project.org/jira (see issue TEST-2 for an example of the comments)
