### PR TITLE
jira_updater: Stop assuming there is only one ID for the Resolve transition.

### DIFF
--- a/github_webhooks/internal_settings.py.sample
+++ b/github_webhooks/internal_settings.py.sample
@@ -45,8 +45,9 @@ JIRA_VERIFY_SSL = True
 # The Jira project string used as a prefix for issues IDs
 JIRA_PROJECT = ''
 
-# The ID of the "Resolve" transition
-JIRA_TRANSITION_RESOLVE_ID = ''
+# The name of the transition that corresponds to resolving a ticket
+# For example, "Resolve".
+JIRA_TRANSITION_RESOLVE_NAME = ''
 
 # The ID of the "Fixed" resolution
 JIRA_RESOLUTION_FIXED_ID = ''

--- a/jira_updater/test_handlers.py
+++ b/jira_updater/test_handlers.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.test import TestCase
 from django.test.client import Client
+from django.test.utils import override_settings
 
 from github_webhooks.test.utils import GitHubEventClient
 from github_webhooks.test.utils import mock_pull_request_payload
@@ -52,6 +53,7 @@ class JiraUpdaterTestCase(TestCase):
         handle_pull_request(None, payload=payload)
         jira_mock.return_value.add_comment.assert_called_with('PROJ-2', ANY)
 
+    @override_settings(JIRA_TRANSITION_RESOLVE_NAME='Resolve')
     @patch('jira_updater.jirahelper.JIRA')
     def test_resolve_issue(self, jira_mock):
         payload = mock_pull_request_payload()
@@ -62,13 +64,30 @@ class JiraUpdaterTestCase(TestCase):
             '\n'\
             'BUG=https://crosswalk-project.org/jira/bug=PROJ-2'
         payload['pull_request']['merged'] = True
+
         issue_mock = Mock()
         jira_mock.return_value.issue.return_value = issue_mock
+        jira_mock.return_value.transitions.return_value = (
+            {'id': '1', 'name': 'Triage'},
+            {'id': '2', 'name': 'Resolve'},
+        )
         handle_pull_request(None, payload=payload)
         jira_mock.return_value.issue.assert_called_with('PROJ-2')
         jira_mock.return_value.add_comment.assert_called_with('PROJ-2', ANY)
         jira_mock.return_value.transition_issue.assert_called_with(
             issue_mock,
-            settings.JIRA_TRANSITION_RESOLVE_ID,
+            '2',
             resolution={'id': settings.JIRA_RESOLUTION_FIXED_ID}
             )
+
+        issue_mock = Mock()
+        jira_mock.return_value.issue.return_value = issue_mock
+        jira_mock.return_value.transitions.return_value = (
+            {'id': '1', 'name': 'Triage'},
+            {'id': '2', 'name': 'Close'},
+            {'id': '5', 'name': 'New'},
+        )
+        handle_pull_request(None, payload=payload)
+        self.assertTrue(jira_mock.return_value.transitions.call_count, 1)
+        self.assertTrue(jira_mock.return_value.add_comment.call_count, 0)
+        self.assertTrue(jira_mock.return_value.transition_issue.call_count, 0)


### PR DESCRIPTION
It turns out that the ID of the "Resolve" transition varies according to the 
current state an issue is at (it may not even exist).

Take that into account and now query the server for the ID corresponding to 
that transition. It introduces some latency as it means another query to the 
JIRA server, but it should be bearable for now.

BUG=XWALK-1078
