### PR TITLE
trybot_control: Properly quote builder name in the status URL

### DIFF
--- a/trybot_control/models.py
+++ b/trybot_control/models.py
@@ -4,6 +4,7 @@
 
 import json
 import requests
+import urllib
 
 from django.conf import settings
 from django.db import models
@@ -77,7 +78,8 @@ class PullRequest(models.Model):
         for builder in self.trybotbuild_set.all():
             message += '%s | [%s](%s/builders/%s/builds/%d)\n' % \
                        (builder.builder_name, builder.get_status_display(),
-                        settings.TRYBOT_BASE_URL, builder.builder_name,
+                        settings.TRYBOT_BASE_URL,
+                        urllib.quote(builder.builder_name),
                         builder.build_number)
 
         url = 'https://api.github.com/repos/%s/issues/comments/%d' % \

--- a/trybot_control/test_models.py
+++ b/trybot_control/test_models.py
@@ -68,7 +68,7 @@ class PullRequestTestCase(TestCase):
 Bot | Status
 --- | ------
 crosswalk-linux | [In Progress](http://tryb.ot/builders/crosswalk-linux/builds/42)
-Crosswalk Tizen | [**SUCCESS** :green_heart:](http://tryb.ot/builders/Crosswalk Tizen/builds/34)
+Crosswalk Tizen | [**SUCCESS** :green_heart:](http://tryb.ot/builders/Crosswalk%20Tizen/builds/34)
 '''
 
         self.assertEqual(mock_request.call_count, 1)
@@ -84,7 +84,7 @@ Crosswalk Tizen | [**SUCCESS** :green_heart:](http://tryb.ot/builders/Crosswalk 
         )
         pr.report_builder_statuses()
 
-        message += 'XWalk Windows | [**FAILED** :broken_heart:](http://tryb.ot/builders/XWalk Windows/builds/3)\n'
+        message += 'XWalk Windows | [**FAILED** :broken_heart:](http://tryb.ot/builders/XWalk%20Windows/builds/3)\n'
 
         self.assertEqual(mock_request.call_count, 2)
         self.assertEqual(mock_request.call_args,


### PR DESCRIPTION
Something changed in GitHub a few weeks ago and it no longer seems to be
escaping URLs on its own (e.g. "foo bar" does not become "foo%20bar"). This
broke the tables we post when reporting a builder's status when the
builder's name contains spaces.

Make sure we quote the name correctly before posting it.